### PR TITLE
Bugfix/downgrade formly bootstrap

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "lodash": "~2.4.1",
     "angular-ui-router": "~0.2.15",
     "angular-formly": "~7.2.3",
-    "angular-formly-templates-bootstrap": "~6.1.5",
+    "angular-formly-templates-bootstrap": "~4.3.2",
     "easy-form-generator": "~1.0.32"
   },
   "devDependencies": {
@@ -24,7 +24,7 @@
   },
   "resolutions": {
     "angular-bootstrap": "~0.13.3",
-    "angular-formly-templates-bootstrap": "~6.1.5",
+    "angular-formly-templates-bootstrap": "~4.3.2",
     "angular-formly": ">=4.0.5",
     "lodash": "~3.9.3",
     "bootstrap": "~3.3.5"

--- a/client/index.html
+++ b/client/index.html
@@ -18,7 +18,7 @@
       <link rel="stylesheet" href="bower_components/animate.css/animate.css" />
       <link rel="stylesheet" href="bower_components/angularjs-toaster/toaster.css" />
       <link rel="stylesheet" href="bower_components/nya-bootstrap-select/dist/css/nya-bs-select.css" />
-      <link rel="stylesheet" href="bower_components/easy-form-generator/dist/public/css/eda.stepway.css" />
+      <link rel="stylesheet" href="bower_components/easy-form-generator/dist/css/eda.stepway.min.css" />
       <!-- endbower -->
     <!-- endbuild -->
     <link rel="stylesheet" href="https://gitcdn.xyz/repo/angular/bower-material/master/angular-material.css">
@@ -61,11 +61,8 @@
       <script src="bower_components/angular-bootstrap/ui-bootstrap-tpls.js"></script>
       <script src="bower_components/lodash/lodash.js"></script>
       <script src="bower_components/angular-ui-router/release/angular-ui-router.js"></script>
-<<<<<<< HEAD
-<<<<<<< HEAD
       <!-- endbower -->
     <!-- endbuild -->
-=======
       <script src="bower_components/api-check/dist/api-check.js"></script>
       <script src="bower_components/angular-formly/dist/formly.js"></script>
       <script src="bower_components/angular-animate/angular-animate.js"></script>


### PR DESCRIPTION
This fixes an apiCheck error when loading the site. Newer versions of the bootstrap form templates rely on features in newer versions of angular-formly.