### PR TITLE
Update the form_gen process and make the roles editable after form has been created

### DIFF
--- a/client/app/admin/admin.jade
+++ b/client/app/admin/admin.jade
@@ -18,6 +18,9 @@ div(ng-include='"components/navbar/navbar.html"')
     li.list-group-item(ng-repeat='form in forms')
       a(href='/form/{{form._id}}')
         strong {{form.name}}
+        br
+        a(href="form/{{form._id}}/roles")
+          span.text-muted Edit Roles
       a.trash(ng-click='deleteForm(form)')
         span.glyphicon.glyphicon-trash.pull-right
 

--- a/client/app/form/form.controller.js
+++ b/client/app/form/form.controller.js
@@ -2,34 +2,55 @@
 
 angular.module('thinkKidsCertificationProgramApp')
   .controller('FormCtrl', function ($scope, $http, $stateParams, $location, Auth) {
-    $http.get('/api/roles')
-        .success(function(roles) {
-            $scope.roles = roles.map(function(role) {
-                role.permitted = false;
-                return role;
-            });
-        });
+    $scope.viewForm = false;
 
     $scope.saveForm = function(data) {
-        var roles = $scope.$$childHead.roles.filter(function(role) {
-            return role.permitted === true;
-        }).map(function(role) {
-            return role.name;
+        $http.post('/api/forms', { name: data.formName, data: [data], roles: []}).success(function(form) {
+            $location.path("/form/" + form._id + "/roles");
         });
-
-        $http.post('/api/forms', { name: data.formName, data: [data], roles: roles });
-    	$location.path('/admin');
     };
 
-    if($stateParams.id) {
-      $scope.hasForm = true;
-    	$http.get('/api/forms/'+$stateParams.id)
-    		.success(function(form) {
+    if($stateParams.formID) {
+        $http.get('/api/roles')
+            .success(function(roles) {
+                $http.get('/api/forms/' + $stateParams.formID)
+                    .success(function(form) {
+                        $scope.roles = roles.map(function(role) {
+                            if(form.roles.indexOf(role.name) !== -1) {
+                                role.permitted = true;
+                            } else {
+                                role.permitted = false;   
+                            }
+                            return role;
+                        });
+                        $scope.roles = $scope.roles.splice(3, $scope.roles.length-3);
+                    })
+            });
+        
+        $scope.saveRoles = function(data) {
+            var roles = data.filter(function(role) {
+                return role.permitted === true;
+            }).map(function(role) {
+                return role.name;
+            });
+            
+            $http.patch('/api/forms/'+$stateParams.formID, {roles: roles})
+                .success(function(form) {
+                   location.path("/admin");
+                });
+         };  
+    }
 
+    if($stateParams.id) {
+        $scope.viewForm = true;
+        
+        $http.get('/api/forms/'+$stateParams.id)
+            .success(function(form) {
+        
                 var permitted = form.roles.filter(function(role) {
                     return Auth.getCurrentUser().roles.indexOf(role) !== -1;
                 }).length;
-
+        
                 if(permitted == 0) {
                     $location.path("/");
                 } else {
@@ -38,16 +59,16 @@ angular.module('thinkKidsCertificationProgramApp')
                     $scope.form.btnCancelText = form.data[0].btnCancelText;
                     $scope.form.fieldsModel = form.data[0].edaFieldsModel;
                     $scope.form.dataModel = {};
-
+        
                     $scope.form.submitFormEvent = function(dataSubmitted) {
                         console.log("Form submitted");
                         console.log("Here's your data: " + dataSubmitted);
                     };
-
+        
                     $scope.form.cancelFormEvent = function() {
                         console.log("Form cancelled!");
                     };
                 }
-    		});
+            });
     }
   });

--- a/client/app/form/form.jade
+++ b/client/app/form/form.jade
@@ -1,10 +1,4 @@
 div(ng-include='"components/navbar/navbar.html"')
 .container
-  md-list(ng-controller="FormCtrl" ng-hide="hasForm" ng-cloak)
-     md-subheader(class="md-no-sticky")
-       | Choose which users are allowed to fill the form
-     md-list-item(ng-repeat="role in roles")
-       p {{role.name}} ({{role.permitted}})
-       md-checkbox(class="md-secondary", ng-model="role.permitted")
-  eda-step-way-easy-form-gen(ng-hide="hasForm", eda-easy-form-generator-model="edaEasyFormGeneratorModel", eda-save-form-event="saveForm(edaEasyFormGeneratorModel)")
-  eda-easy-form-viewer(ng-show="hasForm", eda-easy-form-viewer-data-model="form.dataModel", eda-easy-form-viewer-easy-form-generator-fields-model="form.fieldsModel", eda-easy-form-viewer-submit-button-text="{{ form.btnSubmitText }}", eda-easy-form-viewer-cancel-button-text="{{ form.btnCancelText }}", eda-easy-form-viewer-submit-form-event="form.submitFormEvent(dataSubmitted)", eda-easy-form-viewer-cancel-form-event="form.cancelFormEvent()")
+  eda-step-way-easy-form-gen(ng-hide="viewForm", eda-easy-form-generator-model="edaEasyFormGeneratorModel", eda-save-form-event="saveForm(edaEasyFormGeneratorModel)")
+  eda-easy-form-viewer(ng-show="viewForm", eda-easy-form-viewer-data-model="form.dataModel", eda-easy-form-viewer-easy-form-generator-fields-model="form.fieldsModel", eda-easy-form-viewer-submit-button-text="{{ form.btnSubmitText }}", eda-easy-form-viewer-cancel-button-text="{{ form.btnCancelText }}", eda-easy-form-viewer-submit-form-event="form.submitFormEvent(dataSubmitted)", eda-easy-form-viewer-cancel-form-event="form.cancelFormEvent()")

--- a/client/app/form/form.js
+++ b/client/app/form/form.js
@@ -8,6 +8,11 @@ angular.module('thinkKidsCertificationProgramApp')
         templateUrl: 'app/form/form.html',
         controller: 'FormCtrl'
       })
+      .state('formRoles', {
+        url: '/form/:formID/roles',
+        templateUrl: 'app/form/roles.html',
+        controller: 'FormCtrl'
+      })
       .state('formView', {
       	url: '/form/:id',
       	templateUrl: 'app/form/form.html',

--- a/client/app/form/roles.jade
+++ b/client/app/form/roles.jade
@@ -1,0 +1,10 @@
+div(ng-include='"components/navbar/navbar.html"')
+.container
+  md-list(ng-controller="FormCtrl", ng-cloak)
+    md-subheader(class="md-no-sticky")
+      | Choose which users are allowed to fill the form
+    md-list-item(ng-repeat="role in roles")
+      p {{role.name}}
+      md-checkbox(class="md-secondary", ng-model="role.permitted")
+    md-button(class="md-raised md-primary", ng-click="saveRoles(roles)")
+      | Save

--- a/server/api/form/index.js
+++ b/server/api/form/index.js
@@ -9,8 +9,8 @@ var router = express.Router();
 router.get('/', controller.index);
 router.get('/:id', controller.show);
 router.post('/', auth.can("create_forms"), controller.create);
-router.put('/:id', controller.update);
-router.patch('/:id', controller.update);
+router.put('/:id', auth.can("create_forms"), controller.update);
+router.patch('/:id', auth.can("create_forms"), controller.update);
 router.delete('/:id', auth.can("delete_forms"), controller.destroy);
 
 module.exports = router;


### PR DESCRIPTION
I created a new template for the roles and a new route. The same route/template is used for adding the roles initially when creating the form and for updating them later, if that is necessary.

The roles can be edited by clicking the 'Edit roles' link I added in the admin panel.

The URL of the new route is: /form/:formID/roles.