### PR TITLE
Add feedback feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ client/bower_components
 dist
 /server/config/local.env.js
 npm-debug.log
+client/.DS_Store

--- a/client/app/form/data.jade
+++ b/client/app/form/data.jade
@@ -1,12 +1,31 @@
 div(ng-include='"components/navbar/navbar.html"')
-.container
+.container(ng-hide="isFeedback")
   ul.list-group
     li.list-group-item(ng-repeat='data in form.submittedData', ng-show="showData")
-      strong Submitted by 
-        a(href="/form/{{form._id}}/data/{{data.by}}")
+      strong
+        a(href="/form/{{form._id}}/data/{{data.onTime}}")
           {{data.byName}}
+        | 's submission
+      em  ({{data.grade}})
+      a(href="/form/{{form._id}}/data/{{data.onTime}}/feedback/view", ng-show="showFeedback")
+        em  Show feedback
       a.trash(ng-click='deleteData(data)')
         span.glyphicon.glyphicon-trash.pull-right
-    li.list-group-item(ng-repeat='data in data', ng-hide="showData")
-      strong {{data.prop}} 
-      span.text-muted {{data.val}}
+    div(ng-hide="showData")
+      a(href="/form/{{form._id}}/data")
+        | Back
+      li.list-group-item(ng-repeat='data in data')
+        strong {{data.prop}}
+        span.text-muted  {{data.val}}
+      br
+      button.btn.btn-lg.btn-success(ng-show="isInstructor", ng-click="pass()")
+        | Pass
+      br
+      br
+      button.btn.btn-lg.btn-danger(ng-show="isInstructor", ng-click="fail()")
+        | Fail
+.container(ng-show="isFeedback")
+  ul.list-group
+    li.list-group-item(ng-repeat='data in data')
+      strong {{data.prop}}
+      span.text-muted  {{data.val}}

--- a/client/app/form/feedback.jade
+++ b/client/app/form/feedback.jade
@@ -1,0 +1,7 @@
+div(ng-include='"components/navbar/navbar.html"')
+.container
+  p Please choose a feedback form:
+  ul.list-group
+    li.list-group-item(ng-repeat='form in forms')
+      a(href='/form/{{formID}}/data/{{onTime}}/feedback/new/{{form._id}}')
+        strong {{form.name}}

--- a/client/app/form/form.controller.js
+++ b/client/app/form/form.controller.js
@@ -6,7 +6,6 @@ angular.module('thinkKidsCertificationProgramApp')
       if(window.location.pathname.indexOf('roles') > -1) {
         $http.get('/api/roles')
           .success(function(roles) {
-            console.log(roles);
             $http.get('/api/forms/' + $stateParams.id)
               .success(function(form) {
                 $scope.roles = roles.filter(function(role) {
@@ -15,13 +14,13 @@ angular.module('thinkKidsCertificationProgramApp')
                   if(form.roles.indexOf(role.name) !== -1) {
                     role.permitted = true;
                   } else {
-                    role.permitted = false;   
+                    role.permitted = false;
                   }
                   return role;
                 });
               });
           });
-        
+
         $scope.saveRoles = function(data) {
           var roles = data.filter(function(role) {
             return role.permitted === true;
@@ -30,59 +29,192 @@ angular.module('thinkKidsCertificationProgramApp')
           });
           roles.push('admin');
           roles.push('inst');
-          $http.patch('/api/forms/'+$stateParams.id, {roles: roles})
+
+          var isFeedback;
+
+          if($scope.isFeedback === 'Yes') {
+            isFeedback = true;
+          } else {
+            isFeedback = false;
+          }
+
+          $http.patch('/api/forms/'+$stateParams.id, {roles: roles, isFeedback: isFeedback})
             .success(function() {
               $location.path('/admin');
             });
          };
       } else if (window.location.pathname.indexOf('data') > -1) {
-        $http.get('/api/forms/' + $stateParams.id)
-          .success(function(form) {
-            $scope.form = form;
-            
-            if($stateParams.by) {
-              $scope.showData = false;
-              
-             $scope.form.submittedData = $scope.form.submittedData.filter(function(data) {
-                return data.by === $stateParams.by;
+        if(window.location.pathname.indexOf('feedback') > -1) {
+          if(window.location.pathname.indexOf('new') > -1) {
+            $http.get('/api/forms/' + $stateParams.formId)
+              .success(function(form) {
+                $scope.form = form;
+                $scope.form.btnSubmitText = form.data[0].btnSubmitText;
+                $scope.form.btnCancelText = form.data[0].btnCancelText;
+                $scope.form.fieldsModel = form.data[0].edaFieldsModel;
+                $scope.form.dataModel = {};
+                $scope.viewForm = true;
+
+                $scope.form.submitFormEvent = function() {
+                  var formFieldsData = form.data[0].edaFieldsModel;
+                  var formSubmittedDataProps = Object.getOwnPropertyNames($scope.form.dataModel);
+                  var formSubmittedData = {};
+
+                  for(var i = 0; i < formSubmittedDataProps.length; i++) {
+                    for(var x = 1; x < formFieldsData.length; x++) {
+                      for(var y = 0; y < formFieldsData[x].columns.length; y++) {
+                        if(formFieldsData[x].columns[y].control.key === formSubmittedDataProps[i]) {
+                          formSubmittedData[formFieldsData[x].columns[y].control.templateOptions.label] = $scope.form.dataModel[formSubmittedDataProps[i]];
+                        }
+                      }
+                    }
+                  }
+
+                  formSubmittedData.onTime = Math.floor(Date.now() / 1000);
+                  formSubmittedData.byName = Auth.getCurrentUser().name;
+
+                  form.submittedData.push(formSubmittedData);
+                  formSubmittedData = form.submittedData;
+                  $http.get('/api/forms/' + $stateParams.id)
+                    .success(function(form) {
+                      var formData = form.submittedData.map(function(data) {
+                        if(String(data.onTime) === String($stateParams.onTime)) {
+                          data.feedback = formSubmittedData;
+                        }
+
+                        return data;
+                      });
+
+                      $http.patch('/api/forms/'+$stateParams.id, {submittedData: formData})
+                        .success(function() {
+                          $location.path('/');
+                        });
+                    });
+                };
               });
-              $scope.form.submittedData = $scope.form.submittedData[0];
-              
-              var dataProps = Object.getOwnPropertyNames($scope.form.submittedData);
-              var data = [];
-              
-              for(var i = 0; i < dataProps.length; i++) {
-                if(dataProps[i] === 'byName') {
-                  continue;
-                } else if(dataProps[i] === 'by') {
-                  continue;
-                } else {
-                  var tempData = {};
-                  tempData.prop = dataProps[i];
-                  tempData.val = $scope.form.submittedData[dataProps[i]];
-                  data.push(tempData);
+          } else if (window.location.pathname.indexOf('view') > -1) {
+            $http.get('/api/forms/'+$stateParams.id)
+              .success(function(form) {
+                $scope.isFeedback = true;
+                $scope.data = form.submittedData.filter(function(data) {
+                  return data.feedback && String(data.onTime) === String($stateParams.onTime);
+                });
+                $scope.data = $scope.data[0].feedback[0];
+                var dataProps = Object.getOwnPropertyNames($scope.data);
+                var data = [];
+
+                for(var i = 0; i < dataProps.length; i++) {
+                  if(dataProps[i] === 'byName') {
+                    continue;
+                  } else if(dataProps[i] === 'onTime') {
+                    continue;
+                  } else if(dataProps[i] === 'grade') {
+                    continue;
+                  } else {
+                    var tempData = {};
+                    tempData.prop = dataProps[i];
+                    tempData.val = $scope.data[dataProps[i]];
+                    data.push(tempData);
+                  }
                 }
+                $scope.data = data;
+              });
+          } else {
+            $http.get('/api/forms')
+              .success(function(forms) {
+                $scope.forms = forms.filter(function(forms) {
+                  return forms.isFeedback;
+                });
+                $scope.formID = $stateParams.id;
+                $scope.onTime = $stateParams.onTime;
+              });
+          }
+        } else {
+          $http.get('/api/forms/' + $stateParams.id)
+            .success(function(form) {
+              $scope.form = $.extend(true, {}, form);
+              if($stateParams.onTime) {
+                $scope.showData = false;
+                $scope.isInstructor = Auth.getCurrentUser().role === 'admin' || Auth.getCurrentUser().role === 'inst';
+
+                $scope.pass = function() {
+                  var submittedData = form.submittedData.map(function(data) {
+                    if (String(data.onTime) === String($stateParams.onTime)) {
+                      data.grade = 'Pass';
+                    }
+                    return data;
+                  });
+
+                  $http.patch('/api/forms/' + $stateParams.id, {submittedData: submittedData});
+                  $location.path('/form/'+$stateParams.id+'/data/'+$stateParams.onTime+'/feedback');
+                };
+
+                $scope.fail = function() {
+                  var submittedData = form.submittedData.map(function(data) {
+                    if (String(data.onTime) === String($stateParams.onTime)) {
+                      data.grade = 'Fail';
+                    }
+                    return data;
+                  });
+
+                  $http.patch('/api/forms/' + $stateParams.id, {submittedData: submittedData});
+                  $location.path('/form/'+$stateParams.id+'/data/'+$stateParams.onTime+'/feedback');
+                };
+
+                $scope.form.submittedData = $scope.form.submittedData.filter(function(data) {
+                  return String(data.onTime) === String($stateParams.onTime);
+                });
+                $scope.form.submittedData = $scope.form.submittedData[0];
+
+                var dataProps = Object.getOwnPropertyNames($scope.form.submittedData);
+                var data = [];
+
+                for(var i = 0; i < dataProps.length; i++) {
+                  if(dataProps[i] === 'byName') {
+                    continue;
+                  } else if(dataProps[i] === 'onTime') {
+                    continue;
+                  } else if(dataProps[i] === 'grade') {
+                    continue;
+                  } else {
+                    var tempData = {};
+                    tempData.prop = dataProps[i];
+                    tempData.val = $scope.form.submittedData[dataProps[i]];
+                    data.push(tempData);
+                  }
+                }
+                $scope.data = data;
+              } else {
+                $scope.form.submittedData = $scope.form.submittedData.map(function(data) {
+                  if(data.grade === undefined) {
+                    data.grade = 'Not graded';
+                  }
+
+                  if(data.feedback !== undefined) {
+                    $scope.showFeedback = true;
+                  }
+
+                  return data;
+                });
+
+                $scope.showData = true;
+                $scope.deleteData = function(data) {
+                  form.submittedData.splice(form.submittedData.indexOf(data), 1);
+                  var submittedData = form.submittedData;
+                  $http.patch('/api/forms/'+$stateParams.id, {submittedData: submittedData});
+                };
               }
-              $scope.data = data;
-              console.log(data);
-            } else {
-              $scope.showData = true;
-              $scope.deleteData = function(data) {
-                form.submittedData.splice(form.submittedData.indexOf(data), 1);
-                var submittedData = form.submittedData;
-                $http.patch('/api/forms/'+$stateParams.id, {submittedData: submittedData});
-              };
-            }
-          });
+            });
+          }
       } else if (window.location.pathname.indexOf('data') === -1 && window.location.pathname.indexOf('roles') === -1) {
         $scope.viewForm = true;
-        
+
         $http.get('/api/forms/'+$stateParams.id)
-          .success(function(form) {      
+          .success(function(form) {
             var permitted = form.roles.filter(function(role) {
               return Auth.getCurrentUser().roles.indexOf(role) !== -1;
             }).length;
-    
+
             if(permitted === 0) {
               $location.path('/');
             } else {
@@ -96,25 +228,28 @@ angular.module('thinkKidsCertificationProgramApp')
                 var formFieldsData = form.data[0].edaFieldsModel;
                 var formSubmittedDataProps = Object.getOwnPropertyNames($scope.form.dataModel);
                 var formSubmittedData = {};
-                    
+
                 for(var i = 0; i < formSubmittedDataProps.length; i++) {
                   for(var x = 1; x < formFieldsData.length; x++) {
                     for(var y = 0; y < formFieldsData[x].columns.length; y++) {
                       if(formFieldsData[x].columns[y].control.key === formSubmittedDataProps[i]) {
-                        formSubmittedData[formFieldsData[x].columns[y].control.templateOptions.label] = $scope.form.dataModel[formSubmittedDataProps[i]];        
+                        formSubmittedData[formFieldsData[x].columns[y].control.templateOptions.label] = $scope.form.dataModel[formSubmittedDataProps[i]];
                       }
                     }
                   }
                 }
-                    
-                formSubmittedData.by = Auth.getCurrentUser()._id;
+
+                formSubmittedData.onTime = Math.floor(Date.now() / 1000);
                 formSubmittedData.byName = Auth.getCurrentUser().name;
-                
+
                 form.submittedData.push(formSubmittedData);
                 formSubmittedData = form.submittedData;
-                $http.patch('/api/forms/'+$stateParams.id, {submittedData: formSubmittedData});
+                $http.patch('/api/forms/'+$stateParams.id, {submittedData: formSubmittedData})
+                  .success(function() {
+                    $location.path('/');
+                  });
               };
-    
+
               $scope.form.cancelFormEvent = function() {
                 console.log('Form cancelled!');
               };

--- a/client/app/form/form.controller.js
+++ b/client/app/form/form.controller.js
@@ -1,221 +1,18 @@
 'use strict';
 
 angular.module('thinkKidsCertificationProgramApp')
-  .controller('FormCtrl', function ($scope, $http, $stateParams, $location, Auth) {
-    if($stateParams.id) {
-      if(window.location.pathname.indexOf('roles') > -1) {
-        $http.get('/api/roles')
-          .success(function(roles) {
-            $http.get('/api/forms/' + $stateParams.id)
-              .success(function(form) {
-                $scope.roles = roles.filter(function(role) {
-                  return role.name !== 'user' && role.name !== 'inst' && role.name !== 'admin';
-                }).map(function(role) {
-                  if(form.roles.indexOf(role.name) !== -1) {
-                    role.permitted = true;
-                  } else {
-                    role.permitted = false;
-                  }
-                  return role;
-                });
-              });
-          });
-
-        $scope.saveRoles = function(data) {
-          var roles = data.filter(function(role) {
-            return role.permitted === true;
-          }).map(function(role) {
-            return role.name;
-          });
-          roles.push('admin');
-          roles.push('inst');
-
-          var isFeedback;
-
-          if($scope.isFeedback === 'Yes') {
-            isFeedback = true;
-          } else {
-            isFeedback = false;
-          }
-
-          $http.patch('/api/forms/'+$stateParams.id, {roles: roles, isFeedback: isFeedback})
-            .success(function() {
-              $location.path('/admin');
-            });
-         };
-      } else if (window.location.pathname.indexOf('data') > -1) {
-        if(window.location.pathname.indexOf('feedback') > -1) {
-          if(window.location.pathname.indexOf('new') > -1) {
-            $http.get('/api/forms/' + $stateParams.formId)
-              .success(function(form) {
-                $scope.form = form;
-                $scope.form.btnSubmitText = form.data[0].btnSubmitText;
-                $scope.form.btnCancelText = form.data[0].btnCancelText;
-                $scope.form.fieldsModel = form.data[0].edaFieldsModel;
-                $scope.form.dataModel = {};
-                $scope.viewForm = true;
-
-                $scope.form.submitFormEvent = function() {
-                  var formFieldsData = form.data[0].edaFieldsModel;
-                  var formSubmittedDataProps = Object.getOwnPropertyNames($scope.form.dataModel);
-                  var formSubmittedData = {};
-
-                  for(var i = 0; i < formSubmittedDataProps.length; i++) {
-                    for(var x = 1; x < formFieldsData.length; x++) {
-                      for(var y = 0; y < formFieldsData[x].columns.length; y++) {
-                        if(formFieldsData[x].columns[y].control.key === formSubmittedDataProps[i]) {
-                          formSubmittedData[formFieldsData[x].columns[y].control.templateOptions.label] = $scope.form.dataModel[formSubmittedDataProps[i]];
-                        }
-                      }
-                    }
-                  }
-
-                  formSubmittedData.onTime = Math.floor(Date.now() / 1000);
-                  formSubmittedData.byName = Auth.getCurrentUser().name;
-
-                  form.submittedData.push(formSubmittedData);
-                  formSubmittedData = form.submittedData;
-                  $http.get('/api/forms/' + $stateParams.id)
-                    .success(function(form) {
-                      var formData = form.submittedData.map(function(data) {
-                        if(String(data.onTime) === String($stateParams.onTime)) {
-                          data.feedback = formSubmittedData;
-                        }
-
-                        return data;
-                      });
-
-                      $http.patch('/api/forms/'+$stateParams.id, {submittedData: formData})
-                        .success(function() {
-                          $location.path('/');
-                        });
-                    });
-                };
-              });
-          } else if (window.location.pathname.indexOf('view') > -1) {
-            $http.get('/api/forms/'+$stateParams.id)
-              .success(function(form) {
-                $scope.isFeedback = true;
-                $scope.data = form.submittedData.filter(function(data) {
-                  return data.feedback && String(data.onTime) === String($stateParams.onTime);
-                });
-                $scope.data = $scope.data[0].feedback[0];
-                var dataProps = Object.getOwnPropertyNames($scope.data);
-                var data = [];
-
-                for(var i = 0; i < dataProps.length; i++) {
-                  if(dataProps[i] === 'byName') {
-                    continue;
-                  } else if(dataProps[i] === 'onTime') {
-                    continue;
-                  } else if(dataProps[i] === 'grade') {
-                    continue;
-                  } else {
-                    var tempData = {};
-                    tempData.prop = dataProps[i];
-                    tempData.val = $scope.data[dataProps[i]];
-                    data.push(tempData);
-                  }
-                }
-                $scope.data = data;
-              });
-          } else {
-            $http.get('/api/forms')
-              .success(function(forms) {
-                $scope.forms = forms.filter(function(forms) {
-                  return forms.isFeedback;
-                });
-                $scope.formID = $stateParams.id;
-                $scope.onTime = $stateParams.onTime;
-              });
-          }
-        } else {
-          $http.get('/api/forms/' + $stateParams.id)
-            .success(function(form) {
-              $scope.form = $.extend(true, {}, form);
-              if($stateParams.onTime) {
-                $scope.showData = false;
-                $scope.isInstructor = Auth.getCurrentUser().role === 'admin' || Auth.getCurrentUser().role === 'inst';
-
-                $scope.pass = function() {
-                  var submittedData = form.submittedData.map(function(data) {
-                    if (String(data.onTime) === String($stateParams.onTime)) {
-                      data.grade = 'Pass';
-                    }
-                    return data;
-                  });
-
-                  $http.patch('/api/forms/' + $stateParams.id, {submittedData: submittedData});
-                  $location.path('/form/'+$stateParams.id+'/data/'+$stateParams.onTime+'/feedback');
-                };
-
-                $scope.fail = function() {
-                  var submittedData = form.submittedData.map(function(data) {
-                    if (String(data.onTime) === String($stateParams.onTime)) {
-                      data.grade = 'Fail';
-                    }
-                    return data;
-                  });
-
-                  $http.patch('/api/forms/' + $stateParams.id, {submittedData: submittedData});
-                  $location.path('/form/'+$stateParams.id+'/data/'+$stateParams.onTime+'/feedback');
-                };
-
-                $scope.form.submittedData = $scope.form.submittedData.filter(function(data) {
-                  return String(data.onTime) === String($stateParams.onTime);
-                });
-                $scope.form.submittedData = $scope.form.submittedData[0];
-
-                var dataProps = Object.getOwnPropertyNames($scope.form.submittedData);
-                var data = [];
-
-                for(var i = 0; i < dataProps.length; i++) {
-                  if(dataProps[i] === 'byName') {
-                    continue;
-                  } else if(dataProps[i] === 'onTime') {
-                    continue;
-                  } else if(dataProps[i] === 'grade') {
-                    continue;
-                  } else {
-                    var tempData = {};
-                    tempData.prop = dataProps[i];
-                    tempData.val = $scope.form.submittedData[dataProps[i]];
-                    data.push(tempData);
-                  }
-                }
-                $scope.data = data;
-              } else {
-                $scope.form.submittedData = $scope.form.submittedData.map(function(data) {
-                  if(data.grade === undefined) {
-                    data.grade = 'Not graded';
-                  }
-
-                  if(data.feedback !== undefined) {
-                    $scope.showFeedback = true;
-                  }
-
-                  return data;
-                });
-
-                $scope.showData = true;
-                $scope.deleteData = function(data) {
-                  form.submittedData.splice(form.submittedData.indexOf(data), 1);
-                  var submittedData = form.submittedData;
-                  $http.patch('/api/forms/'+$stateParams.id, {submittedData: submittedData});
-                };
-              }
-            });
-          }
-      } else if (window.location.pathname.indexOf('data') === -1 && window.location.pathname.indexOf('roles') === -1) {
+  .controller('FormCtrl', function($scope, $http, $stateParams, $location, Auth) {
+    if ($stateParams.id) {
+      if (window.location.pathname.indexOf('data') === -1 && window.location.pathname.indexOf('roles') === -1) {
         $scope.viewForm = true;
 
-        $http.get('/api/forms/'+$stateParams.id)
+        $http.get('/api/forms/' + $stateParams.id)
           .success(function(form) {
             var permitted = form.roles.filter(function(role) {
               return Auth.getCurrentUser().roles.indexOf(role) !== -1;
             }).length;
 
-            if(permitted === 0) {
+            if (permitted === 0) {
               $location.path('/');
             } else {
               $scope.form = {};
@@ -229,10 +26,10 @@ angular.module('thinkKidsCertificationProgramApp')
                 var formSubmittedDataProps = Object.getOwnPropertyNames($scope.form.dataModel);
                 var formSubmittedData = {};
 
-                for(var i = 0; i < formSubmittedDataProps.length; i++) {
-                  for(var x = 1; x < formFieldsData.length; x++) {
-                    for(var y = 0; y < formFieldsData[x].columns.length; y++) {
-                      if(formFieldsData[x].columns[y].control.key === formSubmittedDataProps[i]) {
+                for (var i = 0; i < formSubmittedDataProps.length; i++) {
+                  for (var x = 1; x < formFieldsData.length; x++) {
+                    for (var y = 0; y < formFieldsData[x].columns.length; y++) {
+                      if (formFieldsData[x].columns[y].control.key === formSubmittedDataProps[i]) {
                         formSubmittedData[formFieldsData[x].columns[y].control.templateOptions.label] = $scope.form.dataModel[formSubmittedDataProps[i]];
                       }
                     }
@@ -244,7 +41,9 @@ angular.module('thinkKidsCertificationProgramApp')
 
                 form.submittedData.push(formSubmittedData);
                 formSubmittedData = form.submittedData;
-                $http.patch('/api/forms/'+$stateParams.id, {submittedData: formSubmittedData})
+                $http.patch('/api/forms/' + $stateParams.id, {
+                    submittedData: formSubmittedData
+                  })
                   .success(function() {
                     $location.path('/');
                   });
@@ -260,7 +59,12 @@ angular.module('thinkKidsCertificationProgramApp')
       $scope.viewForm = false;
 
       $scope.saveForm = function(data) {
-        $http.post('/api/forms', { name: data.formName, submittedData: [], data: [data], roles: []}).success(function(form) {
+        $http.post('/api/forms', {
+          name: data.formName,
+          submittedData: [],
+          data: [data],
+          roles: []
+        }).success(function(form) {
           $location.path('/form/' + form._id + '/roles');
         });
       };

--- a/client/app/form/form.data.controller.js
+++ b/client/app/form/form.data.controller.js
@@ -1,0 +1,175 @@
+'use strict';
+
+angular.module('thinkKidsCertificationProgramApp')
+  .controller('FormDataCtrl', function($scope, $http, $stateParams, $location, Auth) {
+    if (window.location.pathname.indexOf('feedback') > -1) {
+      if (window.location.pathname.indexOf('new') > -1) {
+        $http.get('/api/forms/' + $stateParams.formId)
+          .success(function(form) {
+            $scope.form = form;
+            $scope.form.btnSubmitText = form.data[0].btnSubmitText;
+            $scope.form.btnCancelText = form.data[0].btnCancelText;
+            $scope.form.fieldsModel = form.data[0].edaFieldsModel;
+            $scope.form.dataModel = {};
+            $scope.viewForm = true;
+
+            $scope.form.submitFormEvent = function() {
+              var formFieldsData = form.data[0].edaFieldsModel;
+              var formSubmittedDataProps = Object.getOwnPropertyNames($scope.form.dataModel);
+              var formSubmittedData = {};
+
+              for (var i = 0; i < formSubmittedDataProps.length; i++) {
+                for (var x = 1; x < formFieldsData.length; x++) {
+                  for (var y = 0; y < formFieldsData[x].columns.length; y++) {
+                    if (formFieldsData[x].columns[y].control.key === formSubmittedDataProps[i]) {
+                      formSubmittedData[formFieldsData[x].columns[y].control.templateOptions.label] = $scope.form.dataModel[formSubmittedDataProps[i]];
+                    }
+                  }
+                }
+              }
+
+              formSubmittedData.onTime = Math.floor(Date.now() / 1000);
+              formSubmittedData.byName = Auth.getCurrentUser().name;
+
+              form.submittedData.push(formSubmittedData);
+              formSubmittedData = form.submittedData;
+              $http.get('/api/forms/' + $stateParams.id)
+                .success(function(form) {
+                  var formData = form.submittedData.map(function(data) {
+                    if (String(data.onTime) === String($stateParams.onTime)) {
+                      data.feedback = formSubmittedData;
+                    }
+
+                    return data;
+                  });
+
+                  $http.patch('/api/forms/' + $stateParams.id, {
+                      submittedData: formData
+                    })
+                    .success(function() {
+                      $location.path('/');
+                    });
+                });
+            };
+          });
+      } else if (window.location.pathname.indexOf('view') > -1) {
+        $http.get('/api/forms/' + $stateParams.id)
+          .success(function(form) {
+            $scope.isFeedback = true;
+            $scope.data = form.submittedData.filter(function(data) {
+              return data.feedback && String(data.onTime) === String($stateParams.onTime);
+            });
+            $scope.data = $scope.data[0].feedback[0];
+            var dataProps = Object.getOwnPropertyNames($scope.data);
+            var data = [];
+
+            for (var i = 0; i < dataProps.length; i++) {
+              if (dataProps[i] === 'byName') {
+                continue;
+              } else if (dataProps[i] === 'onTime') {
+                continue;
+              } else if (dataProps[i] === 'grade') {
+                continue;
+              } else {
+                var tempData = {};
+                tempData.prop = dataProps[i];
+                tempData.val = $scope.data[dataProps[i]];
+                data.push(tempData);
+              }
+            }
+            $scope.data = data;
+          });
+      } else {
+        $http.get('/api/forms')
+          .success(function(forms) {
+            $scope.forms = forms.filter(function(forms) {
+              return forms.isFeedback;
+            });
+            $scope.formID = $stateParams.id;
+            $scope.onTime = $stateParams.onTime;
+          });
+      }
+    } else {
+      $http.get('/api/forms/' + $stateParams.id)
+        .success(function(form) {
+          $scope.form = $.extend(true, {}, form);
+          if ($stateParams.onTime) {
+            $scope.showData = false;
+            $scope.isInstructor = Auth.getCurrentUser().role === 'admin' || Auth.getCurrentUser().role === 'inst';
+
+            $scope.pass = function() {
+              var submittedData = form.submittedData.map(function(data) {
+                if (String(data.onTime) === String($stateParams.onTime)) {
+                  data.grade = 'Pass';
+                }
+                return data;
+              });
+
+              $http.patch('/api/forms/' + $stateParams.id, {
+                submittedData: submittedData
+              });
+              $location.path('/form/' + $stateParams.id + '/data/' + $stateParams.onTime + '/feedback');
+            };
+
+            $scope.fail = function() {
+              var submittedData = form.submittedData.map(function(data) {
+                if (String(data.onTime) === String($stateParams.onTime)) {
+                  data.grade = 'Fail';
+                }
+                return data;
+              });
+
+              $http.patch('/api/forms/' + $stateParams.id, {
+                submittedData: submittedData
+              });
+              $location.path('/form/' + $stateParams.id + '/data/' + $stateParams.onTime + '/feedback');
+            };
+
+            $scope.form.submittedData = $scope.form.submittedData.filter(function(data) {
+              return String(data.onTime) === String($stateParams.onTime);
+            });
+            $scope.form.submittedData = $scope.form.submittedData[0];
+
+            var dataProps = Object.getOwnPropertyNames($scope.form.submittedData);
+            var data = [];
+
+            for (var i = 0; i < dataProps.length; i++) {
+              if (dataProps[i] === 'byName') {
+                continue;
+              } else if (dataProps[i] === 'onTime') {
+                continue;
+              } else if (dataProps[i] === 'grade') {
+                continue;
+              } else {
+                var tempData = {};
+                tempData.prop = dataProps[i];
+                tempData.val = $scope.form.submittedData[dataProps[i]];
+                data.push(tempData);
+              }
+            }
+            $scope.data = data;
+          } else {
+            $scope.form.submittedData = $scope.form.submittedData.map(function(data) {
+              if (data.grade === undefined) {
+                data.grade = 'Not graded';
+              }
+
+              if (data.feedback !== undefined) {
+                $scope.showFeedback = true;
+              }
+
+              return data;
+            });
+
+            $scope.showData = true;
+            $scope.deleteData = function(data) {
+              form.submittedData.splice(form.submittedData.indexOf(data), 1);
+              var submittedData = form.submittedData;
+              $http.patch('/api/forms/' + $stateParams.id, {
+                submittedData: submittedData
+              });
+            };
+          }
+        });
+    }
+  });

--- a/client/app/form/form.js
+++ b/client/app/form/form.js
@@ -16,31 +16,31 @@ angular.module('thinkKidsCertificationProgramApp')
       .state('formRoles', {
         url: '/form/:id/roles',
         templateUrl: 'app/form/roles.html',
-        controller: 'FormCtrl'
+        controller: 'FormRolesCtrl'
       })
       .state('formData', {
         url: '/form/:id/data',
         templateUrl: 'app/form/data.html',
-        controller: 'FormCtrl'
+        controller: 'FormDataCtrl'
       })
       .state('formUserData', {
         url: '/form/:id/data/:onTime',
         templateUrl: 'app/form/data.html',
-        controller: 'FormCtrl'
+        controller: 'FormDataCtrl'
       })
       .state('formUserDataFeedbackFormChoose', {
         url: '/form/:id/data/:onTime/feedback',
         templateUrl: 'app/form/feedback.html',
-        controller: 'FormCtrl'
+        controller: 'FormDataCtrl'
       })
       .state('formUserDataFeedbackForm', {
         url: '/form/:id/data/:onTime/feedback/new/:formId',
         templateUrl: 'app/form/form.html',
-        controller: 'FormCtrl'
+        controller: 'FormDataCtrl'
       })
       .state('formUserDataFeedbackView', {
         url: '/form/:id/data/:onTime/feedback/view',
         templateUrl: 'app/form/data.html',
-        controller: 'FormCtrl'
+        controller: 'FormDataCtrl'
       });
   });

--- a/client/app/form/form.js
+++ b/client/app/form/form.js
@@ -24,7 +24,22 @@ angular.module('thinkKidsCertificationProgramApp')
         controller: 'FormCtrl'
       })
       .state('formUserData', {
-        url: '/form/:id/data/:by',
+        url: '/form/:id/data/:onTime',
+        templateUrl: 'app/form/data.html',
+        controller: 'FormCtrl'
+      })
+      .state('formUserDataFeedbackFormChoose', {
+        url: '/form/:id/data/:onTime/feedback',
+        templateUrl: 'app/form/feedback.html',
+        controller: 'FormCtrl'
+      })
+      .state('formUserDataFeedbackForm', {
+        url: '/form/:id/data/:onTime/feedback/new/:formId',
+        templateUrl: 'app/form/form.html',
+        controller: 'FormCtrl'
+      })
+      .state('formUserDataFeedbackView', {
+        url: '/form/:id/data/:onTime/feedback/view',
         templateUrl: 'app/form/data.html',
         controller: 'FormCtrl'
       });

--- a/client/app/form/form.roles.controller.js
+++ b/client/app/form/form.roles.controller.js
@@ -1,0 +1,47 @@
+'use strict';
+
+angular.module('thinkKidsCertificationProgramApp')
+  .controller('FormRolesCtrl', function($scope, $http, $stateParams, $location) {
+    $http.get('/api/roles')
+      .success(function(roles) {
+        $http.get('/api/forms/' + $stateParams.id)
+          .success(function(form) {
+            $scope.roles = roles.filter(function(role) {
+              return role.name !== 'user' && role.name !== 'inst' && role.name !== 'admin';
+            }).map(function(role) {
+              if (form.roles.indexOf(role.name) !== -1) {
+                role.permitted = true;
+              } else {
+                role.permitted = false;
+              }
+              return role;
+            });
+          });
+      });
+
+    $scope.saveRoles = function(data) {
+      var roles = data.filter(function(role) {
+        return role.permitted === true;
+      }).map(function(role) {
+        return role.name;
+      });
+      roles.push('admin');
+      roles.push('inst');
+
+      var isFeedback;
+
+      if ($scope.Feedback === 'Yes') {
+        isFeedback = true;
+      } else {
+        isFeedback = false;
+      }
+
+      $http.patch('/api/forms/' + $stateParams.id, {
+          roles: roles,
+          isFeedback: isFeedback
+        })
+        .success(function() {
+          $location.path('/admin');
+        });
+    };
+  });

--- a/client/app/form/roles.jade
+++ b/client/app/form/roles.jade
@@ -1,6 +1,6 @@
 div(ng-include='"components/navbar/navbar.html"')
 .container
-  md-list(ng-controller="FormCtrl", ng-cloak)
+  md-list(ng-controller="FormRolesCtrl", ng-cloak)
     md-subheader(class="md-no-sticky")
       | Choose which users are allowed to fill the form
     md-list-item(ng-repeat="role in roles")
@@ -9,10 +9,10 @@ div(ng-include='"components/navbar/navbar.html"')
     md-subheader(class="md-no-sticky")
       | Is this an instructor feedback form?
     md-list-item
-      md-radio-group(ng-model="isFeedback")
-        md-radio-button(value="Yes")
+      md-radio-group(ng-model="Feedback")
+        md-radio-button(value="Yes", class="md-primary")
           | Yes
-        md-radio-button(value="No", class="md-primary")
+        md-radio-button(value="No")
           | No
     md-button(class="md-raised md-primary", ng-click="saveRoles(roles)")
       | Save

--- a/client/app/form/roles.jade
+++ b/client/app/form/roles.jade
@@ -6,5 +6,13 @@ div(ng-include='"components/navbar/navbar.html"')
     md-list-item(ng-repeat="role in roles")
       p {{role.name}}
       md-checkbox(class="md-secondary", ng-model="role.permitted")
+    md-subheader(class="md-no-sticky")
+      | Is this an instructor feedback form?
+    md-list-item
+      md-radio-group(ng-model="isFeedback")
+        md-radio-button(value="Yes")
+          | Yes
+        md-radio-button(value="No", class="md-primary")
+          | No
     md-button(class="md-raised md-primary", ng-click="saveRoles(roles)")
       | Save

--- a/client/index.html
+++ b/client/index.html
@@ -7,7 +7,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <base href="/">
-    <title></title>
+    <title>Think Kids Certification App</title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width">
     <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->

--- a/client/index.html
+++ b/client/index.html
@@ -104,7 +104,9 @@
           <script src="app/admin/admin.controller.js"></script>
           <script src="app/admin/admin.js"></script>
           <script src="app/form/form.controller.js"></script>
+          <script src="app/form/form.data.controller.js"></script>
           <script src="app/form/form.js"></script>
+          <script src="app/form/form.roles.controller.js"></script>
           <script src="app/main/main.controller.js"></script>
           <script src="app/main/main.js"></script>
           <script src="app/upload/upload.controller.js"></script>

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "grunt-mocha-test": "~0.10.2",
     "grunt-newer": "~0.7.0",
     "grunt-ng-annotate": "^0.2.3",
-    "grunt-node-inspector": "~0.1.5",
+    "grunt-node-inspector": "^0.4.1",
     "grunt-nodemon": "~0.2.0",
     "grunt-open": "~0.2.3",
     "grunt-protractor-runner": "^1.1.0",

--- a/server/api/form/form.model.js
+++ b/server/api/form/form.model.js
@@ -7,7 +7,8 @@ var FormSchema = new Schema({
   name: String,
   data: Array,
   submittedData: Array,
-  roles: Array
+  roles: Array,
+  isFeedback: Boolean
 });
 
 module.exports = mongoose.model('Form', FormSchema);


### PR DESCRIPTION
Quite a lot of changes. The `Form` controller has grown even more convoluted, which is why my next step is to break it into several controllers before I work on the next user story. Changes summarised below:

- Added `Pass` and `Fail` buttons which are only visible to administrators and instructors. Clicking them redirects the user to a form selection pane where they can select one of several feedback forms.

- Forms can be marked as `feedback forms` in their `roles` page.

- Regular form data is saved in the form's document. Feedback form data is saved on the document of the form on which the feedback was given.

- Also changed the form data route from the id of the user that submitted it to the time stamp when it was submitted. The previous route would only display the data recorded when the user submitted the form for the first time. Subsequent submissions weren't viewable.

EDIT: Because this PR isn't merged yet, pushed the refactor to this PR.