### PR TITLE
Do not include Bearer header on all calls. Notably S3 calls must be exempted

### DIFF
--- a/client/app/app.js
+++ b/client/app/app.js
@@ -26,9 +26,11 @@ angular.module('thinkKidsCertificationProgramApp', [
     return {
       // Add authorization token to headers
       request: function (config) {
-        config.headers = config.headers || {};
-        if ($cookieStore.get('token')) {
-          config.headers.Authorization = 'Bearer ' + $cookieStore.get('token');
+        if (!config.skipAuthorization) {
+          config.headers = config.headers || {};
+          if ($cookieStore.get('token')) {
+            config.headers.Authorization = 'Bearer ' + $cookieStore.get('token');
+          }
         }
         return config;
       },


### PR DESCRIPTION
This is a standard config option honored by $http. Since the app is injecting this header we need to honor it too.