### PR TITLE
Overhaul menu bar

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,8 @@
     "easy-form-generator": "https://github.com/matteverson/easyFormGenerator.git",
     "angular-loading-bar": "~0.8.0",
     "angular-material": "~1.0.3",
-    "moment": "~2.11.1"
+    "moment": "~2.11.1",
+    "angular-messages": "^1.5.0"
   },
   "devDependencies": {
     "angular-mocks": ">=1.2.*",

--- a/client/app/app.scss
+++ b/client/app/app.scss
@@ -26,4 +26,5 @@ $fa-font-path: "/bower_components/font-awesome/fonts";
 @import 'roles/fees.scss';
 @import 'upload/upload.scss';
 @import 'modal/modal.scss';
+@import 'navbar/navbar.scss';
 // endinjector

--- a/client/components/navbar/heading.service.js
+++ b/client/components/navbar/heading.service.js
@@ -1,0 +1,16 @@
+'use strict';
+
+angular.module('thinkKidsCertificationProgramApp')
+  .factory('Heading', function Heading() {
+    var heading = '';
+
+    return {
+      getHeading: function() {
+        return heading;
+      },
+
+      setHeading: function(h) {
+        heading = h;
+      }
+    };
+  });

--- a/client/components/navbar/navbar.controller.js
+++ b/client/components/navbar/navbar.controller.js
@@ -1,14 +1,12 @@
 'use strict';
 
 angular.module('thinkKidsCertificationProgramApp')
-  .controller('NavbarCtrl', function ($scope, $location, Auth, $http, $mdSidenav, Heading, $timeout) {
+  .controller('NavbarCtrl', function ($scope, $location, Auth, $http, $mdSidenav, Heading) {
     $scope.toggleMenu = function() {
         $mdSidenav('left').toggle();
     };
 
-    $timeout(function() {
-      $scope.heading = Heading.getHeading();
-    });
+    $scope.heading = Heading.getHeading;
 
     if(Auth.isLoggedIn()) {
       $http.get('/api/users/'+Auth.getCurrentUser()._id)

--- a/client/components/navbar/navbar.controller.js
+++ b/client/components/navbar/navbar.controller.js
@@ -11,7 +11,6 @@ angular.module('thinkKidsCertificationProgramApp')
     });
 
     if(Auth.isLoggedIn()) {
-<<<<<<< 91ed5c025e7721d27f5dba9309b8650404da4bfb
       $http.get('/api/users/'+Auth.getCurrentUser()._id)
         .success(function(user) {
           $scope.newAnnouncement = function() {
@@ -24,24 +23,6 @@ angular.module('thinkKidsCertificationProgramApp')
             if(announcements.length > 0) {
               return true;
             }
-=======
-      $timeout(function() {
-        $scope.newAnnouncement = false;
-        $scope.newMessage = false;
-      });
-
-      $http.get('/api/users/'+Auth.getCurrentUser()._id)
-        .success(function(user) {
-          var announcements = user.announcements.filter(function(item) {
-            return !item.read;
-          });
-
-          if(announcements.length > 0) {
-            $timeout(function() {
-              $scope.newAnnouncement = true;
-            });
-          }
->>>>>>> Add heading to top bar
 
             return false;
           };
@@ -55,16 +36,8 @@ angular.module('thinkKidsCertificationProgramApp')
               return true;
             }
 
-<<<<<<< 91ed5c025e7721d27f5dba9309b8650404da4bfb
             return false;
           };
-=======
-          if(messages.length > 0) {
-            $timeout(function() {
-              $scope.newMessage = true;
-            });
-          }
->>>>>>> Add heading to top bar
       });
     }
 

--- a/client/components/navbar/navbar.controller.js
+++ b/client/components/navbar/navbar.controller.js
@@ -1,11 +1,10 @@
 'use strict';
 
 angular.module('thinkKidsCertificationProgramApp')
-  .controller('NavbarCtrl', function ($scope, $location, Auth, $http) {
-    $scope.menu = [{
-      'title': 'Home',
-      'link': '/'
-    }];
+  .controller('NavbarCtrl', function ($scope, $location, Auth, $http, $mdSidenav) {
+    $scope.toggleMenu = function() {
+        $mdSidenav('left').toggle();
+    };
 
     if(Auth.isLoggedIn()) {
       $http.get('/api/users/'+Auth.getCurrentUser()._id)
@@ -38,7 +37,6 @@ angular.module('thinkKidsCertificationProgramApp')
       });
     }
 
-    $scope.isCollapsed = true;
     $scope.isLoggedIn = Auth.isLoggedIn;
     $scope.isAdmin = Auth.isAdmin;
     $scope.getCurrentUser = Auth.getCurrentUser;
@@ -46,9 +44,5 @@ angular.module('thinkKidsCertificationProgramApp')
     $scope.logout = function() {
       Auth.logout();
       $location.path('/login');
-    };
-
-    $scope.isActive = function(route) {
-      return route === $location.path();
     };
   });

--- a/client/components/navbar/navbar.controller.js
+++ b/client/components/navbar/navbar.controller.js
@@ -1,12 +1,17 @@
 'use strict';
 
 angular.module('thinkKidsCertificationProgramApp')
-  .controller('NavbarCtrl', function ($scope, $location, Auth, $http, $mdSidenav) {
+  .controller('NavbarCtrl', function ($scope, $location, Auth, $http, $mdSidenav, Heading, $timeout) {
     $scope.toggleMenu = function() {
         $mdSidenav('left').toggle();
     };
 
+    $timeout(function() {
+      $scope.heading = Heading.getHeading();
+    });
+
     if(Auth.isLoggedIn()) {
+<<<<<<< 91ed5c025e7721d27f5dba9309b8650404da4bfb
       $http.get('/api/users/'+Auth.getCurrentUser()._id)
         .success(function(user) {
           $scope.newAnnouncement = function() {
@@ -19,6 +24,24 @@ angular.module('thinkKidsCertificationProgramApp')
             if(announcements.length > 0) {
               return true;
             }
+=======
+      $timeout(function() {
+        $scope.newAnnouncement = false;
+        $scope.newMessage = false;
+      });
+
+      $http.get('/api/users/'+Auth.getCurrentUser()._id)
+        .success(function(user) {
+          var announcements = user.announcements.filter(function(item) {
+            return !item.read;
+          });
+
+          if(announcements.length > 0) {
+            $timeout(function() {
+              $scope.newAnnouncement = true;
+            });
+          }
+>>>>>>> Add heading to top bar
 
             return false;
           };
@@ -32,8 +55,16 @@ angular.module('thinkKidsCertificationProgramApp')
               return true;
             }
 
+<<<<<<< 91ed5c025e7721d27f5dba9309b8650404da4bfb
             return false;
           };
+=======
+          if(messages.length > 0) {
+            $timeout(function() {
+              $scope.newMessage = true;
+            });
+          }
+>>>>>>> Add heading to top bar
       });
     }
 

--- a/client/components/navbar/navbar.jade
+++ b/client/components/navbar/navbar.jade
@@ -2,7 +2,7 @@ div(ng-controller='NavbarCtrl', layout="row", ng-show="isLoggedIn()")
   md-sidenav.md-sidenav-left.md-whiteframe-z2(md-component-id="left")
     md-toolbar
       md-button.md-icon-button(aria-label="Open menu bar", ng-click="toggleMenu()")
-        i.fa.fa-bars.pointer
+        i.fa.fa-remove.pointer
       md-toolbar(layout="column", layout-align="center center")  
         img.avatar(src="{{ getCurrentUser().prof.avatar }}")
         h1
@@ -30,11 +30,9 @@ div(ng-controller='NavbarCtrl', layout="row", ng-show="isLoggedIn()")
           a(href='/settings')
             span.glyphicon.glyphicon-cog
           md-divider
-        md-list
-          h6 Notifications
   md-toolbar.top-toolbar
     div.md-toolbar-tools
-      md-button.md-icon-button(aria-label="Open menu bar", ng-click="toggleMenu()")
-        i.fa.fa-bars.pointer
+      md-button.md-primary(aria-label="Open menu bar", ng-click="toggleMenu()")
+        | Menu
       h2 
-        span {{heading}}
+        span {{heading()}}

--- a/client/components/navbar/navbar.jade
+++ b/client/components/navbar/navbar.jade
@@ -1,16 +1,19 @@
 div(ng-controller='NavbarCtrl', layout="row", ng-show="isLoggedIn()")
   md-sidenav.md-sidenav-left.md-whiteframe-z2(md-component-id="left")
-    md-toolbar(layout="column", layout-align="center center")
-      img.avatar(src="{{ getCurrentUser().prof.avatar }}")
-      h1
-        a(href="/{{getCurrentUser()._id}}/profile") {{ getCurrentUser().name }}
-      a(href="#", ng-click="logout()") Logout
+    md-toolbar
+      md-button.md-icon-button(aria-label="Open menu bar", ng-click="toggleMenu()")
+        i.fa.fa-bars.pointer
+      md-toolbar(layout="column", layout-align="center center")  
+        img.avatar(src="{{ getCurrentUser().prof.avatar }}")
+        h1
+          a(href="/{{getCurrentUser()._id}}/profile") {{ getCurrentUser().name }}
+        a(href="#", ng-click="logout()") Logout
     md-content(layout-padding="")
       md-list
-        md-list-item
+        md-list-item.navbar-list
           a(href='/') Home
           md-divider
-        md-list-item(ng-show="isAdmin()")
+        md-list-item.navbar-list(ng-show="isAdmin()")
           a(href='/admin') Admin
           md-divider
         md-list-item(layout="row", layout-align="space-around center")
@@ -31,7 +34,7 @@ div(ng-controller='NavbarCtrl', layout="row", ng-show="isLoggedIn()")
           h6 Notifications
   md-toolbar.top-toolbar
     div.md-toolbar-tools
-      md-button.md-icon-button(aria-label="Open menu bar")
-        i.fa.fa-bars.pointer(ng-click="toggleMenu()")
+      md-button.md-icon-button(aria-label="Open menu bar", ng-click="toggleMenu()")
+        i.fa.fa-bars.pointer
       h2 
         span {{heading}}

--- a/client/components/navbar/navbar.jade
+++ b/client/components/navbar/navbar.jade
@@ -31,4 +31,7 @@ div(ng-controller='NavbarCtrl', layout="row", ng-show="isLoggedIn()")
           h6 Notifications
   md-toolbar.top-toolbar
     div.md-toolbar-tools
-      i.fa.fa-bars.pointer(ng-click="toggleMenu()")
+      md-button.md-icon-button(aria-label="Open menu bar")
+        i.fa.fa-bars.pointer(ng-click="toggleMenu()")
+      h2 
+        span {{heading}}

--- a/client/components/navbar/navbar.jade
+++ b/client/components/navbar/navbar.jade
@@ -1,49 +1,34 @@
-div.navbar.navbar-default.navbar-static-top(ng-controller='NavbarCtrl')
-  div.container
-    div.navbar-header
-      button.navbar-toggle(type='button', ng-click='isCollapsed = !isCollapsed')
-        span.sr-only Toggle navigation
-        span.icon-bar
-        span.icon-bar
-        span.icon-bar
-      a.navbar-brand(href='/') think-kids-certification-program
-
-    div#navbar-main.navbar-collapse.collapse(collapse='isCollapsed')
-      ul.nav.navbar-nav
-        li(ng-repeat='item in menu', ng-class='{active: isActive(item.link)}')
-          a(ng-href='{{item.link}}') {{item.title}}
-
-        li(ng-show='isAdmin()', ng-class='{active: isActive("/admin")}')
+div(ng-controller='NavbarCtrl', layout="row", ng-show="isLoggedIn()")
+  md-sidenav.md-sidenav-left.md-whiteframe-z2(md-component-id="left")
+    md-toolbar(layout="column", layout-align="center center")
+      img.avatar(src="{{ getCurrentUser().prof.avatar }}")
+      h1
+        a(href="/{{getCurrentUser()._id}}/profile") {{ getCurrentUser().name }}
+      a(href="#", ng-click="logout()") Logout
+    md-content(layout-padding="")
+      md-list
+        md-list-item
+          a(href='/') Home
+          md-divider
+        md-list-item(ng-show="isAdmin()")
           a(href='/admin') Admin
-
-      ul.nav.navbar-nav.navbar-right
-        li(ng-hide='isLoggedIn()', ng-class='{active: isActive("/login")}')
-          a(href='/login') Login
-
-        li(ng-show='isLoggedIn()')
-          p.navbar-text Hello&nbsp;
-            a(href="{{ getCurrentUser()._id }}/profile")
-              {{ getCurrentUser().name }}
-
-        li(ng-show='newMessage() && isLoggedIn()')
-          a(href='{{ getCurrentUser()._id }}/messages')
-            i.fa.fa-envelope(style="color: #da5353")
-        
-        li(ng-show='!newMessage() && isLoggedIn()')
-          a(href='{{ getCurrentUser()._id }}/messages')
+          md-divider
+        md-list-item(layout="row", layout-align="space-around center")
+          a(href='{{ getCurrentUser()._id }}/messages', ng-show='newMessage() && isLoggedIn()')
+            i.fa.fa-envelope
+          a(href='{{ getCurrentUser()._id }}/messages', ng-show='!newMessage() && isLoggedIn()')
             i.fa.fa-envelope-o
-        
-        li(ng-show='newAnnouncement() && isLoggedIn()')
-          a(href='announcements')
-            i.fa.fa-bell(style="color: #da5353")
-              
-        li(ng-show='!newAnnouncement() && isLoggedIn()')
-          a(href='announcements')
+          
+          a(href='announcements', ng-show='newAnnouncement() && isLoggedIn()')
+            i.fa.fa-bell
+          a(href='announcements', ng-show='!newAnnouncement() && isLoggedIn()')
             i.fa.fa-bell-o
-        
-        li(ng-show='isLoggedIn()', ng-class='{active: isActive("/settings")}')
+              
           a(href='/settings')
             span.glyphicon.glyphicon-cog
-
-        li(ng-show='isLoggedIn()', ng-class='{active: isActive("/logout")}')
-          a(href='', ng-click='logout()') Logout
+          md-divider
+        md-list
+          h6 Notifications
+  md-toolbar.top-toolbar
+    div.md-toolbar-tools
+      i.fa.fa-bars.pointer(ng-click="toggleMenu()")

--- a/client/components/navbar/navbar.scss
+++ b/client/components/navbar/navbar.scss
@@ -43,10 +43,6 @@ md-toolbar > a:hover, md-toolbar > a:active, md-toolbar > h1 > a:hover, md-toolb
   margin: 16px 0px 0px 0px;
 }
 
-.md-toolbar-tools > .md-icon-button > i {
-  color: #000;
-}
-
 i.fa.fa-envelope, i.fa.fa-bell {
   color: #da5353;
 }

--- a/client/components/navbar/navbar.scss
+++ b/client/components/navbar/navbar.scss
@@ -1,0 +1,56 @@
+.top-toolbar {
+  background-color: #fff !important; /* !important used to override angular material's default toolbar colour */
+}
+
+// md-sidenav {
+//   min-height: 100%;
+// }
+
+md-toolbar > h1 {
+  height: 32px;
+  margin: 15px 0px 0px 0px;
+  font-size: 20px;
+  font-weight: 600;
+}
+
+md-toolbar > h1 > a, md-toolbar > h1 > a:visited {
+  color: rgba(255, 255, 255, 0.8);
+  text-decoration: none;
+}
+
+md-toolbar > a, md-toolbar > a:visited {
+  color: rgba(255, 255, 255, 0.8);
+  text-decoration: none;
+  font-size: 14px;
+  margin-bottom: 16px;
+}
+
+md-toolbar > a:hover, md-toolbar > a:active, md-toolbar > h1 > a:hover, md-toolbar > h1 > a:active {
+  color: rgba(255, 255, 255, 0.8);
+  text-decoration: underline;
+}
+
+md-list-item > a {
+  color: rgba(0, 0, 0, 0.8);
+  text-decration: none;
+}
+
+md-list-item > a:hover {
+  color: rgba(0, 0, 0, 0.8);
+  text-decoration: underline;
+}
+
+.avatar {
+  width: 170px;
+  height: 170px;
+  border-radius: 50%;
+  margin: 16px 0px 0px 0px;
+}
+
+.md-toolbar-tools > i {
+  color: #000;
+}
+
+i.fa.fa-envelope, i.fa.fa-bell {
+  color: #da5353;
+}

--- a/client/components/navbar/navbar.scss
+++ b/client/components/navbar/navbar.scss
@@ -1,10 +1,6 @@
 .top-toolbar {
-  background-color: #fff !important; /* !important used to override angular material's default toolbar colour */
+  background-color: rgba(255, 255, 255, 0) !important; /* !important used to override angular material's default toolbar colour */
 }
-
-// md-sidenav {
-//   min-height: 100%;
-// }
 
 md-toolbar > h1 {
   height: 32px;
@@ -30,12 +26,12 @@ md-toolbar > a:hover, md-toolbar > a:active, md-toolbar > h1 > a:hover, md-toolb
   text-decoration: underline;
 }
 
-md-list-item > a {
+.navbar-list > a {
   color: rgba(0, 0, 0, 0.8);
   text-decration: none;
 }
 
-md-list-item > a:hover {
+.navbar-list > a:hover {
   color: rgba(0, 0, 0, 0.8);
   text-decoration: underline;
 }
@@ -57,4 +53,8 @@ i.fa.fa-envelope, i.fa.fa-bell {
 
 .md-toolbar-tools > h2 {
   color: #000;
+}
+
+md-sidenav, md-backdrop {
+  position: fixed !important;
 }

--- a/client/components/navbar/navbar.scss
+++ b/client/components/navbar/navbar.scss
@@ -47,10 +47,14 @@ md-list-item > a:hover {
   margin: 16px 0px 0px 0px;
 }
 
-.md-toolbar-tools > i {
+.md-toolbar-tools > .md-icon-button > i {
   color: #000;
 }
 
 i.fa.fa-envelope, i.fa.fa-bell {
   color: #da5353;
+}
+
+.md-toolbar-tools > h2 {
+  color: #000;
 }

--- a/client/index.html
+++ b/client/index.html
@@ -134,6 +134,7 @@
           <script src="components/auth/user.service.js"></script>
           <script src="components/modal/modal.service.js"></script>
           <script src="components/mongoose-error/mongoose-error.directive.js"></script>
+          <script src="components/navbar/heading.service.js"></script>
           <script src="components/navbar/navbar.controller.js"></script>
           <!-- endinjector -->
         <!-- endbuild -->


### PR DESCRIPTION
@matteverson, @codenonprofit I need you to take a look at this before its merged. I didn't intend to start work on design until next week, but I thought this was a good idea, so I went ahead and implemented it anyway.

The bootstrap provided menu bar has been replaced by a sidebar that is tucked away into a hamburger menu on the top left. All of the links from the previous menu bar are present in the new one. I've attached a screenshot so that you can take a quick look at it.

You will notice that there is a 'Notifications' heading which is blank. I propose a new mechanism where we compile short excerpts from messages and the announcements and display them under the headings. These can be clicked to view the full message, and archived from the notification panel (the message is still preserved in the individual pages). I suppose this is where the payment reminders could show up too. There could be a payments section in account settings, perhaps, with previous and upcoming payments. I hope that makes sense!

The angular-loading-bar plugin is also conflicting with the hamburger menu, so I propose that we replace it with angular material's indefinite loading bars.

![new-menubar-think-kids-demo](https://cloud.githubusercontent.com/assets/5279150/13043380/cf94179e-d402-11e5-90eb-31b54f7d5c17.gif)