### PR TITLE
Fix submission dates on home page

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -34,6 +34,7 @@
     "lodash": "~3.9.3",
     "bootstrap": "~3.3.5",
     "angular-loading-bar": "~0.8.0",
-    "angular": ">=1"
+    "angular": ">=1",
+    "angular-material": "~1.0.6"
   }
 }


### PR DESCRIPTION
This fixes the issue where the dates weren't being converted from ISO8601 to human readable time. The original solution assumed that the only field with a date in it would have the label "Date", which of course may not be the case.

This solution uses `moment` to validate ISO8601 dates in the submissions. Any ISO8601 dates are  processed before being shown to the user.

I've tested this for any bugs, but it'd be great @matteverson if you could give it a quick look too because I've made some significant changes to existing code that may break the functionality..